### PR TITLE
Scope test #1

### DIFF
--- a/reports/scorecard/scope.json
+++ b/reports/scorecard/scope.json
@@ -23,10 +23,6 @@
         "inclusive-language"
       ],
       "excluded": []
-    },
-    "cisco-ospo": {
-      "included": [],
-      "excluded": []
     }
   }
 }


### PR DESCRIPTION
Testing scope behavior when explicitly removing an org from `scope.json`

## Context

Although `cisco-ospo` mostly contains private repos, there are a [few](https://github.com/cisco-ospo?q=&type=public&language=&sort=) public ones which don't currently appear in the report. 

According to https://github.com/UlisesGascon/openssf-scorecard-monitor/issues/13, public repos _should_ be included when auto-discovery is on.