### PR TITLE
Scope test #2

### DIFF
--- a/reports/scorecard/scope.json
+++ b/reports/scorecard/scope.json
@@ -23,6 +23,10 @@
         "inclusive-language"
       ],
       "excluded": []
+    },
+    "cisco-ospo": {
+      "included": [],
+      "excluded": []
     }
   }
 }

--- a/reports/scorecard/scope.json
+++ b/reports/scorecard/scope.json
@@ -25,7 +25,9 @@
       "excluded": []
     },
     "cisco-ospo": {
-      "included": [],
+      "included": [
+        "oss-template"
+      ],
       "excluded": []
     }
   }


### PR DESCRIPTION
Reverting the exclusion of `cisco-ospo` from `scope.json` and explicitly including one public repository.