### PR TITLE
Use different repository

### DIFF
--- a/reports/scorecard/scope.json
+++ b/reports/scorecard/scope.json
@@ -26,7 +26,7 @@
     },
     "cisco-ospo": {
       "included": [
-        "oss-template"
+        "typescript-action"
       ],
       "excluded": []
     }


### PR DESCRIPTION
Testing a different repository - not sure if Template Repositories are problematic for Scorecard to parse?

Caveat: `typescript-actions` is technically a fork _of_ a template repository, so unsure if same issues will apply. 