### PR TITLE
♻️ Reusable workflow POC for Scorcard

### DIFF
--- a/.github/workflows/_scorecard.yml
+++ b/.github/workflows/_scorecard.yml
@@ -32,15 +32,18 @@ jobs:
         with:
           results_file: ${{ env.RESULTS_PATH }}
           results_format: sarif
-          # Publish the results for public repositories to enable Scorecard badges: https://github.com/ossf/scorecard-action#publishing-results
-          # For private repositories, `publish_results` will automatically be set to `false`, regardless of the value entered here
+          # Publish the results for public repositories to enable Scorecard badges: 
+          # https://github.com/ossf/scorecard-action#publishing-results
+          # For private repositories, `publish_results` will automatically be set to `false`
+          # regardless of the value entered here
           publish_results: true
           # (Optional) fine-grained personal access token (PAT)
-          # Uncomment the `repo_token` line below if you want to enable the Branch-Protection check on a *public* repository
-          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional
+          # Uncomment the `repo_token` line below if you want to enable the Branch-Protection check
+          # on a *public* repository. To create the PAT, follow the steps in: 
+          # https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional
           # repo_token: ${{ secrets.SCORECARD_TOKEN }}
-      # (Optional) Upload the results as SARIF artifacts: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning
-      # Commenting out will disable uploads of run results in SARIF format to the repository Actions tab
+      # (Optional) Upload the results as SARIF artifacts
+      # Commenting out will disable uploads of run results in SARIF format to the Actions tab
       - name: ⏫ upload sarif artifact
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:

--- a/.github/workflows/_scorecard.yml
+++ b/.github/workflows/_scorecard.yml
@@ -1,0 +1,54 @@
+name: _scorecard
+
+on:
+  workflow_call:
+    inputs:
+      publish-results:
+        description: Publish results of Scorecard analysis
+        type: boolean
+        required: false
+        default: true
+
+# Declare default permissions as read-only
+permissions: read-all
+
+env:
+  RESULTS_PATH: "results.sarif"
+
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for code scanning (GitHub CodeQL) alerts
+      security-events: write
+      # Required for GitHub OIDC token (if publish_results: true)
+      id-token: write
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+      - name: ✅ run scorecard analysis
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        with:
+          results_file: ${{ env.RESULTS_PATH }}
+          results_format: sarif
+          # Publish the results for public repositories to enable Scorecard badges: https://github.com/ossf/scorecard-action#publishing-results
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless of the value entered here
+          publish_results: true
+          # (Optional) fine-grained personal access token (PAT)
+          # Uncomment the `repo_token` line below if you want to enable the Branch-Protection check on a *public* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+      # (Optional) Upload the results as SARIF artifacts: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning
+      # Commenting out will disable uploads of run results in SARIF format to the repository Actions tab
+      - name: ⏫ upload sarif artifact
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        with:
+          name: SARIF file
+          path: ${{ env.RESULTS_PATH }}
+          retention-days: 5
+      # Required for code scanning (CodeQL) alerts
+      - name: 📦 upload sarif results
+        uses: github/codeql-action/upload-sarif@b7bf0a3ed3ecfa44160715d7c442788f65f0f923 # v3.23.2
+        with:
+          sarif_file: ${{ env.RESULTS_PATH }}

--- a/.github/workflows/_sync.yml
+++ b/.github/workflows/_sync.yml
@@ -29,13 +29,13 @@ jobs:
         run: echo "${{ secrets.SERVICE_ACCOUNT_TOKEN }}" > token
       - name: 🚮 dump config
         if: inputs.confirm != true && inputs.dump != ''
-        uses: docker://ghcr.io/uwu-tools/peribolos:v0.0.4
+        uses: docker://ghcr.io/uwu-tools/peribolos:v0.0.7
         with:
           github-token-path: ./token
           dump: ${{ inputs.dump }}
       - name: 🔄 run peribolos
         if: (inputs.confirm == true || inputs.confirm == false) && inputs.dump == ''
-        uses: docker://ghcr.io/uwu-tools/peribolos:v0.0.4
+        uses: docker://ghcr.io/uwu-tools/peribolos:v0.0.7
         with:
           github-token-path: ./token
           config-path: org

--- a/.github/workflows/run-scorecard.yml
+++ b/.github/workflows/run-scorecard.yml
@@ -1,0 +1,22 @@
+name: run-scorecard
+
+on:
+  push:
+    branches:
+      # Run on pushes to default branch
+      - develop
+  schedule:
+    # Run weekly on Saturdays
+    - cron: "30 1 * * 6"
+  # Only the default branch is supported
+  branch_protection_rule:
+  # Run the workflow manually
+  workflow_dispatch:
+
+jobs:
+  run-scorecard:
+    # Call reusable workflow file
+    uses: ./.github/workflows/_scorecard.yml
+    with:
+      # Publish results of Scorecard analysis
+      publish-results: true

--- a/.github/workflows/scorecard-monitor.yml
+++ b/.github/workflows/scorecard-monitor.yml
@@ -1,5 +1,5 @@
-name: scorecard-report
-on: 
+name: scorecard-monitor
+on:
   # Scheduled trigger
   schedule:
     # Run every Sunday at 00:00
@@ -16,14 +16,18 @@ permissions:
   issues: write
   packages: none
 
+env:
+  ORG_LIST: "cisco,cisco-open,cisco-ospo"
+  TARGET_BRANCH: "develop"
+
 jobs:
-  security-scoring:
+  scorecard-monitor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: OpenSSF Scorecard Monitor
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: "🔍 run scorecard monitor"
         uses: UlisesGascon/openssf-scorecard-monitor@v2.0.0-beta7
-        id: openssf-scorecard-monitor
+        id: scorecard-monitor
         with:
           scope: reports/scorecard/scope.json
           database: reports/scorecard/database.json
@@ -34,18 +38,18 @@ jobs:
           # The token is needed to create issues, discovery mode and pushing changes in files
           github-token: ${{ secrets.GITHUB_TOKEN }}
           discovery-enabled: true
-          discovery-orgs: 'cisco,cisco-open,cisco-ospo'
-      - name: Print the scores
+          discovery-orgs: ${{ env.ORG_LIST }}
+      - name: "🖨️ print the scores"
         run: |
-          echo '${{ steps.openssf-scorecard-monitor.outputs.scores }}'
-      - name: Create pull request
+          echo '${{ steps.scorecard-monitor.outputs.scores }}'
+      - name: ":octocat: create pull request"
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: OpenSSF Scorecard Report Updated
-          title: OpenSSF Scorecard Report Updated
-          body: OpenSSF Scorecard Report Updated
-          base: develop
+          commit-message: Add latest results to Scorecard Monitor report
+          title: 🔍 Scorecard Monitor Report Update
+          body: This pull request has been automatically filed by Scorecard Monitor.
+          base: ${{ env.TARGET_BRANCH }}
           assignees: ${{ github.actor }}
-          branch: openssf-scorecard-report-updated
+          branch: scorecard-monitor-report-update
           delete-branch: true

--- a/.github/workflows/scorecard-report.yml
+++ b/.github/workflows/scorecard-report.yml
@@ -22,9 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: OpenSSF Scorecard Monitor
-        # NOTE: Temporarily using fork of scorecard monitor action
-        uses: lelia/openssf-scorecard-monitor@scope-debug
-        # uses: UlisesGascon/openssf-scorecard-monitor@v2.0.0-beta6
+        uses: UlisesGascon/openssf-scorecard-monitor@v2.0.0-beta7
         id: openssf-scorecard-monitor
         with:
           scope: reports/scorecard/scope.json


### PR DESCRIPTION
Initial Scorecard workflow pattern for the following scenarios:

- [x] Defining a single reusable workflow configuration at the org level (`cisco-ospo`, in this case)
- [x] Calling this workflow in the same repository the reusable workflow is defined in (`.github`)
- [ ] Calling this workflow in a different repository in the same organization (`cisco-ospo`)
- [ ] Calling this workflow in a different repository in a different organization (`cisco-open`)