### PR TITLE
Reusable workflow permissions fix #2

### DIFF
--- a/.github/workflows/_scorecard.yml
+++ b/.github/workflows/_scorecard.yml
@@ -19,10 +19,10 @@ jobs:
   scorecard:
     runs-on: ubuntu-latest
     permissions:
-      # Required for code scanning (GitHub CodeQL) alerts
-      security-events: write
       # Required for GitHub OIDC token (if publish_results: true)
       id-token: write
+      # Required for code scanning (GitHub CodeQL) alerts
+      security-events: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/.github/workflows/run-scorecard.yml
+++ b/.github/workflows/run-scorecard.yml
@@ -13,11 +13,16 @@ on:
   # Run the workflow manually
   workflow_dispatch:
 
+# Declare default permissions as read-only
+permissions: read-all
+
 jobs:
   run-scorecard:
     # Call reusable workflow file
     uses: ./.github/workflows/_scorecard.yml
-    permissions: read-all
+    permissions:
+      id-token: write
+      security-events: write
     secrets: inherit
     with:
       # Publish results of Scorecard analysis


### PR DESCRIPTION
Explicitly define security+token permissions in calling workflow