### PR TITLE
Scorecard API workflow restrictions

### DIFF
--- a/.github/workflows/_scorecard.yml
+++ b/.github/workflows/_scorecard.yml
@@ -9,19 +9,14 @@ on:
         required: false
         default: true
 
-permissions:
-    # Required for GitHub OIDC token (if publish_results: true)
-    id-token: write
-    # Required for code scanning (GitHub CodeQL) alerts
-    security-events: write
-
-env:
-  # Filename for SARIF results artifact
-  RESULTS_PATH: "results.sarif"
-
 jobs:
   scorecard:
     runs-on: ubuntu-latest
+    permissions:
+        # Required for GitHub OIDC token (if publish_results: true)
+        id-token: write
+        # Required for code scanning (GitHub CodeQL) alerts
+        security-events: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
@@ -29,7 +24,7 @@ jobs:
       - name: ✅ run scorecard analysis
         uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
-          results_file: ${{ env.RESULTS_PATH }}
+          results_file: results.sarif
           results_format: sarif
           # Publish the results for public repositories to enable Scorecard badges: 
           # https://github.com/ossf/scorecard-action#publishing-results
@@ -47,10 +42,10 @@ jobs:
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           name: SARIF file
-          path: ${{ env.RESULTS_PATH }}
+          path: results.sarif
           retention-days: 5
       # Required for code scanning (CodeQL) alerts
       - name: 📦 upload sarif results
         uses: github/codeql-action/upload-sarif@b7bf0a3ed3ecfa44160715d7c442788f65f0f923 # v3.23.2
         with:
-          sarif_file: ${{ env.RESULTS_PATH }}
+          sarif_file: results.sarif


### PR DESCRIPTION
Scorecard run currently fails with error:

```
2024/01/30 22:38:50 error processing signature: error sending scorecard results to webapp: http response 400, status: 400 Bad Request, error: {"code":400,"message":"workflow verification failed: workflow contains global env vars or defaults, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}
```

Due to Scorecard API's [workflow restrictions](https://github.com/ossf/scorecard-action?tab=readme-ov-file#workflow-restrictions) we cannot use global env vars in the workflow files, so these have been removed and some permissions have been re-scoped to be job-specific. 