### PR TITLE
Temporarily changing default branch

### DIFF
--- a/.github/workflows/run-scorecard.yml
+++ b/.github/workflows/run-scorecard.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       # Run on pushes to default branch
-      - develop
+      # - develop
+      # Temporarily changing default branch
+      - main
   schedule:
     # Run weekly on Saturdays
     - cron: "30 1 * * 6"

--- a/.github/workflows/scorecard-monitor.yml
+++ b/.github/workflows/scorecard-monitor.yml
@@ -18,7 +18,9 @@ permissions:
 
 env:
   ORG_LIST: "cisco,cisco-open,cisco-ospo"
-  TARGET_BRANCH: "develop"
+  # Temporarily changing default branch
+  # TARGET_BRANCH: "develop"
+  TARGET_BRANCH: "main"
 
 jobs:
   scorecard-monitor:


### PR DESCRIPTION
Although reusable workflows should [now](https://github.com/ossf/scorecard-webapp/issues/300) be [supported](https://github.com/ossf/scorecard-webapp/pull/295) by the Scorecard API, there appears to be a specific edge case where Scorecard, when run in the context of a reusable workflow that _has a different default branch_ than the calling workflow, will fail during the results publication stage of the GitHub Action:

```
2024/01/30 23:58:54 error sending scorecard results to webapp: http response 400, status: 400 Bad Request, error: {"code":400,"message":"workflow verification failed: branch of cert isn't the repo's default branch, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}
```

Ref: https://github.com/cisco-ospo/sample-project/actions/runs/7719025635/job/21041490540

After temporarily changing the default branch of the [reusable workflow](https://github.com/cisco-ospo/.github/blob/main/.github/workflows/_scorecard.yml) repository (`cisco-ospo/.github`) from `develop` to `main` so that it matches the [calling workflow](https://github.com/cisco-ospo/sample-project/blob/main/.github/workflows/scorecard.yml#L23) repository (`cisco-ospo/sample-project`)'s default `main` branch, Scorecard runs and publishes the results without issue: https://github.com/cisco-ospo/sample-project/actions/runs/7719144312/job/21041843243

Note that updating the `uses:` definition in the calling workflow from `@develop` to `@main` did _not_ fix the issue, even though the reusable workflow exists on both branches of `cisco-ospo/.github`. The default branch must be changed either in the GitHub Settings UI or the `settings.yml` file of the repository which hosts the reusable workflow.

More context:
- https://github.com/ossf/scorecard-action#workflow-restrictions
- https://github.com/ossf/scorecard-webapp/blob/9c2f66d5f6ff56ca4a4ac2fba6ec8dcc5379d31c/app/server/post_results.go#L184-L187