### PR TITLE
Add missing quotation

### DIFF
--- a/.github/workflows/evergreen-check.yml
+++ b/.github/workflows/evergreen-check.yml
@@ -28,7 +28,7 @@ jobs:
           PREVIOUS_DATE=$(date -d "$CURRENT_DATE -7 day" +'%Y-%m-%d')
           echo "$PREVIOUS_DATE..$CURRENT_DATE"
           # Create env variable for next step
-          echo "ONE_WEEK_AGO=$PREVIOUS_DATE >> "$GITHUB_ENV"
+          echo "ONE_WEEK_AGO=$PREVIOUS_DATE" >> "$GITHUB_ENV"
       - name: 🌲 evergreen check
         uses: github/evergreen@c7f90d59873562e19509fbdb47187ba7c0a8a73e # v1.4.0
         env:


### PR DESCRIPTION
Advanced workflow example provided by GitHub was [missing a quotation mark](https://github.com/github/evergreen/commit/be7e46ba89fea13130e9e8a21c659dbc585418a9#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R101) for an environment variable.

Bonus: Looks like someone caught this around the exact same time as me 😆 https://github.com/github/evergreen/pull/49