### PR TITLE
Create initial POC workflow for contributor report

### DIFF
--- a/.github/workflows/contributor-report.yml
+++ b/.github/workflows/contributor-report.yml
@@ -1,0 +1,45 @@
+name: Weekly contributor report
+
+on:
+  # Scheduled trigger
+  schedule:
+    # Run every Sunday at 00:00
+    - cron: "0 0 * * 0"
+  # Manual trigger
+  workflow_dispatch:
+
+permissions:
+  issues: none
+
+jobs:
+  contributor-report:
+    runs-on: ubuntu-latest
+    permissions:
+        # Required to create issues
+        issues: write
+    steps:
+      - name: 📅 calculate date
+        shell: bash
+        run: |
+          # Calculate the first day of the previous month
+          START_DATE=$(date -d "last month" +%Y-%m-01)
+          # Calculate the last day of the previous month
+          END_DATE=$(date -d "$START_DATE +1 month -1 day" +%Y-%m-%d)
+          # Set an environment variable with the date range
+          echo "START_DATE=$START_DATE" >> "$GITHUB_ENV"
+          echo "END_DATE=$END_DATE" >> "$GITHUB_ENV"
+      - name: 📰 run contributor action
+        uses: github/contributors@4e02ca47bd8730be5edbbf1669eb58b8345cfef8 # v1.1.3
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          START_DATE: ${{ env.START_DATE }}
+          END_DATE: ${{ env.END_DATE }}
+          ORGANIZATION: cisco-ospo
+          LINK_TO_PROFILE: true
+      - name: 📥 create issue
+        uses: peter-evans/create-issue-from-file@24452a72d85239eacf1468b0f1982a9f3fec4c94 # v5.0.0
+        with:
+          title: 📰 Monthly Contributor Report
+          token: ${{ secrets.GITHUB_TOKEN }}
+          content-filepath: ./contributors.md
+          assignees: ${{ github.actor }}


### PR DESCRIPTION
Initial proof-of-concept to evaluate the [contributors](https://github.com/github/contributors) action as a possible solution for tracking Cisco contributions across our open source projects. For testing purposes, only the `cisco-ospo` organization is being targeted, and should furnish a report weekly (or can be triggered manually).  

**Open questions:**
* Support for tracking non-Cisco-led projects (eg. projects we don't own/administer)
* Support for discerning between Cisco and non-Cisco employee contributions