### PR TITLE
Contributors POC workflow fixes

### DIFF
--- a/.github/workflows/contributor-report.yml
+++ b/.github/workflows/contributor-report.yml
@@ -3,8 +3,8 @@ name: contributor-report
 on:
   # Scheduled trigger
   schedule:
-    # Run every Sunday at 00:00
-    - cron: "0 0 * * 0"
+    # Run the first day of the month at 00:00
+    - cron: "0 0 1 * *"
   # Manual trigger
   workflow_dispatch:
 
@@ -35,7 +35,6 @@ jobs:
           START_DATE: ${{ env.START_DATE }}
           END_DATE: ${{ env.END_DATE }}
           ORGANIZATION: cisco-ospo
-          LINK_TO_PROFILE: "true"
       - name: 📥 create issue
         uses: peter-evans/create-issue-from-file@24452a72d85239eacf1468b0f1982a9f3fec4c94 # v5.0.0
         with:

--- a/.github/workflows/contributor-report.yml
+++ b/.github/workflows/contributor-report.yml
@@ -28,7 +28,7 @@ jobs:
           # Set an environment variable with the date range
           echo "START_DATE=$START_DATE" >> "$GITHUB_ENV"
           echo "END_DATE=$END_DATE" >> "$GITHUB_ENV"
-      - name: 📰 run contributor action
+      - name: 📰 run contributors action
         uses: github/contributors@4e02ca47bd8730be5edbbf1669eb58b8345cfef8 # v1.1.3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changes:

- Fixes `cron` schedule to be monthly, rather than weekly, to match the issue and date calculation logic
- Removes `LINK_TO_PROFILE` parameter, which appears to either be broken or unnecessary (docs say the default value is already set to `"True"`)