### PR TITLE
Add basic dependency review workflow for evaluation

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+name: dependency-review
+
+on:
+  pull_request:
+
+permissions:
+  contents: none
+  pull-requests: none
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: 🔒 harden runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+            egress-policy: audit
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: 🔂 dependency review
+        uses: actions/dependency-review-action@9129d7d40b8c12c1ed0f60400d00c92d437adcce # v4.1.3
+        with:
+            deny-licenses: AGPL-3.0
+            fail-on-severity: moderate
+            comment-summary-in-pr: true


### PR DESCRIPTION
This is a fairly barebones workflow POC for evaluating the [dependency review action](https://github.com/actions/dependency-review-action) (more info [here](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review))

TODO:
- Determine what failure threshold we're comfortable with
- Create definitive allow / denylists of licenses
- Explore other configurable options / inputs
- Create a single-source-of-truth [config file](https://github.com/actions/dependency-review-action?tab=readme-ov-file#configuration-file) for repos to inherit / be referenced in templates