### PR TITLE
Add initial proof of concept for cleaning `CODEOWNERS`

### DIFF
--- a/.github/workflows/clean-owners.yml
+++ b/.github/workflows/clean-owners.yml
@@ -1,4 +1,4 @@
-name: evergreen-check
+name: clean-owners
 
 on:
   # Scheduled trigger
@@ -14,6 +14,8 @@ permissions:
 jobs:
   clean-owners:
     runs-on: ubuntu-latest
+    permissions:
+        issues: write
     steps:
       - name: 🧼 clean codeowners
         uses: github/cleanowners@6e9f77116c2528ea49f31bb3b830bc2a31129f8a # no semver release yet

--- a/.github/workflows/clean-owners.yml
+++ b/.github/workflows/clean-owners.yml
@@ -1,0 +1,24 @@
+name: evergreen-check
+
+on:
+  # Scheduled trigger
+  schedule:
+    # Run weekly on Saturdays
+    - cron: "30 1 * * 6"
+  # Manual trigger
+  workflow_dispatch:
+
+permissions:
+  issues: none
+
+jobs:
+  clean-owners:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🧼 clean codeowners
+        uses: github/cleanowners@6e9f77116c2528ea49f31bb3b830bc2a31129f8a # no semver release yet
+        env:
+          GH_TOKEN: ${{ secrets.CISCO_SERVICE_TOKEN }}
+          ORGANIZATION: cisco-ospo
+          EXEMPT_REPOS: "cisco-ospo/.github, cisco-ospo/.allstar"
+          DRY_RUN: true

--- a/.github/workflows/evergreen-check.yml
+++ b/.github/workflows/evergreen-check.yml
@@ -1,4 +1,5 @@
 name: evergreen-check
+
 on:
   # Scheduled trigger
   schedule:

--- a/.github/workflows/evergreen-check.yml
+++ b/.github/workflows/evergreen-check.yml
@@ -32,7 +32,7 @@ jobs:
       #     # Create env variable for next step
       #     echo "ONE_WEEK_AGO=$PREVIOUS_DATE" >> "$GITHUB_ENV"
       - name: 🌲 evergreen check
-        uses: github/evergreen@b6e56d1ae29adaebd9367b80ac4f1beb67dac69f # v1.6.0
+        uses: github/evergreen@c405c0af2b8af6e89131327fd5b619b12ded6dc7 # v1.7.0
         env:
           GH_TOKEN: ${{ secrets.CISCO_SERVICE_TOKEN }}
           ORGANIZATION: cisco-ospo


### PR DESCRIPTION
Basic POC for testing GitHub's new [cleanowners](https://github.com/github/cleanowners) action tool for keeping `CODEOWNERS` files up-to-date.

Notably, much of the configuration is very similar to [evergreen](https://github.com/github/evergreen), so there may be a future opportunity to combine these workflows into a singular stream. 