### PR TITLE
Add real issue number to test token functionality

### DIFF
--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: peter-evans/create-or-update-comment@v3
         with:
           token: ${{ steps.app-token.outputs.token }}
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: 117
           body: "Hello, World!"


### PR DESCRIPTION
refs: #121 + #122

If working as intended, the workflow should be able to generate an ephemeral token in order to authenticate the next step, which is leaving a comment on an Issue (#117 in this case)