### PR TITLE
Adding write permissions for Issues

### DIFF
--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -2,9 +2,14 @@ name: app-test
 
 on: [workflow_dispatch]
 
+permissions:
+    issues: none
+
 jobs:
   hello-world:
     runs-on: ubuntu-latest
+    permissions:
+        issues: write
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token


### PR DESCRIPTION
Need to grant `issues: write` permissions to workflow in order to leave an Issue comment (ref: #123)