### PR TITLE
Temporary scorecard-monitor workflow update to fix report links

### DIFF
--- a/.github/workflows/scorecard-monitor.yml
+++ b/.github/workflows/scorecard-monitor.yml
@@ -31,7 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: 🔍 run scorecard monitor
-        uses: ossf/scorecard-monitor@8551177324543b39670fe3c430012c946a937bd1 # v2.0.0-beta7
+        uses: ossf/scorecard-monitor@main # temporarily using main until v2.0.0-beta8 is released
+        #uses: ossf/scorecard-monitor@8551177324543b39670fe3c430012c946a937bd1 # v2.0.0-beta7
         id: scorecard-monitor
         with:
           scope: reports/scorecard/scope.json


### PR DESCRIPTION
This upstream bug was fixed in https://github.com/ossf/scorecard-monitor/pull/83, but according to [this conversation](https://github.com/ossf/scorecard-monitor/issues/79#issuecomment-2181688340) a few things still need to happen before a new version tag (eg. `v2.0.0-beta8`) can be released. Updating workflow to temporarily use `main` so we can continue generating Scorecard Monitor reports with accurate result links. 